### PR TITLE
Add project documentation

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Samuel Valdes Gutierrez
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,38 @@
 <!-- omit in toc -->
 # OpenSearch-bot
 
-This project contains the source code for a GitHub App that automates the release process in OpenSearch repositories. The app works as follows:
+![MIT License](https://img.shields.io/badge/license-MIT-blue)
+![GitHub contributors](https://img.shields.io/github/contributors/BigSamu/OpenSearch-bot)
+![Coverage Badge](./badges/coverage.svg)
+
+This project contains the source code for a GitHub App that automates the release process in OpenSearch repositories.
+
+<!-- omit in toc -->
+## Table of Contents
+- [Installation](#installation)
+  - [Installing on an OpenSearch Repository](#installing-on-an-opensearch-repository)
+  - [Installing on Forked Repositories](#installing-on-forked-repositories)
+- [Features](#features)
+- [License](#license)
+
+## Installation
+
+In order for the app to work as intended, it must be installed both on an OpenSearch repository as well as on any forked repositories that PRs originate from.
+
+### Installing on an OpenSearch Repository
+
+- Navigate to the [OpenSearch-bot](https://github.com/apps/opensearch-bot) installation page and click "Install". 
+- Select the OpenSearch repository where this app will manage PRs and process changeset files.
+- Follow the instructions to complete the installation.
+
+### Installing on Forked Repositories
+
+- In the forked OpenSearch repository, navigate to the [OpenSearch-bot](https://github.com/apps/opensearch-bot) installation page and click "Install".
+- Follow the instructions to complete the installation on the forked repository.
+
+## Features
+
+The app works as follows:
 
 1. **PR Changelog Processing:** When a user opens a pull request (PR) from a forked repository against an OpenSearch repository, the app scans the PR description, looking for changelog entries listed in a "Changelog" section. It then generates a changeset file from these entries and commits this file to the open PR.
    
@@ -9,31 +40,6 @@ This project contains the source code for a GitHub App that automates the releas
 
 This process ensures a streamlined and automated approach to maintaining up-to-date release documentation in OpenSearch repositories.
 
-<!-- omit in toc -->
-## Table of Contents
-- [Installation](#installation)
-  - [Installation for Repository Usage](#installation-for-repository-usage)
-    - [Installing on an OpenSearch Repository](#installing-on-an-opensearch-repository)
-    - [Installing on Forked Repositories](#installing-on-forked-repositories)
+## License
 
-## Installation
-
-This section outlines the steps for installing and setting up the `OpenSearch-bot` GitHub App. It addresses:
-- Users who want to install the app on repositories they own or maintain. 
-- Developers interested in contributing to or customizing the source code for their own use cases.
-
-### Installation for Repository Usage
-
-In order for the app to work as intended, it must be installed both on an OpenSearch repository as well as on any forked repositories that PRs originate from.
-
-#### Installing on an OpenSearch Repository
-
-- Navigate to the [OpenSearch-bot](https://github.com/apps/opensearch-bot) installation page and click "Install". 
-- Select the OpenSearch repository where this app will manage PRs and process changeset files.
-- Follow the instructions to complete the installation.
-
-#### Installing on Forked Repositories
-
-- In the forked OpenSearch repository, navigate to the [OpenSearch-bot](https://github.com/apps/opensearch-bot) installation page and click "Install".
-- Follow the instructions to complete the installation on the forked repository.
-
+This app is licensed under the MIT License.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 # OpenSearch-bot
 
 This project contains the source code for a GitHub App that automates the release process in OpenSearch repositories. The app works as follows:
+
 1. **PR Changelog Processing:** When a user opens a pull request (PR) from a forked repository against an OpenSearch repository, the app scans the PR description, looking for changelog entries listed in a "Changelog" section. It then generates a changeset file from these entries and commits this file to the open PR.
+   
 2. **Automating Release Documentation:** When the PR is merged, the changeset file is stored in a designated directory in the base repository. At the time of a new release, the app scans this directory and uses the changeset files to generate comprehensive release notes and update the changelog with new entries.
 
 This process ensures a streamlined and automated approach to maintaining up-to-date release documentation in OpenSearch repositories.
@@ -13,15 +15,6 @@ This process ensures a streamlined and automated approach to maintaining up-to-d
   - [Installation for Repository Usage](#installation-for-repository-usage)
     - [Installing on an OpenSearch Repository](#installing-on-an-opensearch-repository)
     - [Installing on Forked Repositories](#installing-on-forked-repositories)
-  - [Setting Up the Codebase for Development](#setting-up-the-codebase-for-development)
-    - [Fork the `OpenSearch-bot` Repository](#fork-the-opensearch-bot-repository)
-    - [Use `ngrok` to Create a Secure Tunnel to Localhost](#use-ngrok-to-create-a-secure-tunnel-to-localhost)
-    - [Register Your Own GitHub App](#register-your-own-github-app)
-      - [Starting the Process](#starting-the-process)
-      - [Configuring the App](#configuring-the-app)
-      - [Finalizing App Settings](#finalizing-app-settings)
-    - [Create a `.gitignore` File](#create-a-gitignore-file)
-    - [Create a `.env` File](#create-a-env-file)
 
 ## Installation
 
@@ -44,98 +37,3 @@ In order for the app to work as intended, it must be installed both on an OpenSe
 - In the forked OpenSearch repository, navigate to the [OpenSearch-bot](https://github.com/apps/opensearch-bot) installation page and click "Install".
 - Follow the instructions to complete the installation on the forked repository.
 
-### Setting Up the Codebase for Development
-
-For developers who would like to contribute to the `OpenSearch-bot` source code or customize it for their own use cases, the following instructions lay out the process for setting up a local development environment.
-
-#### Fork the `OpenSearch-bot` Repository
-
-- Create your own fork of the `OpenSearch-bot` repository on GitHub.
-- Clone your forked repository onto your local machine.
-- From the root directory of your forked repository, run `npm i` to install all project dependencies.
-
-#### Use `ngrok` to Create a Secure Tunnel to Localhost
-
-This GitHub App relies on webhooks for its functionality. To test your changes, you will need to register your own GitHub App (instructions below) and configure it with a webhook URL. Use `ngrok` to set up a secure tunnel to your local server for webhook testing.
-
-- Download and install `ngrok` from [ngrok.com/download](https://ngrok.com/download).
-- Sign up for a free `ngrok` account to receive an authtoken for your configuration.
-- Start an `ngrok` tunnel with the command `ngrok http [port]` (e.g., `ngrok http 3000`).
-- The "Forwarding" URL displayed by `ngrok` (e.g., `https://****-****.ngrok-free.app`) will serve as the base of the webhook URL you will need below.
-
-#### Register Your Own GitHub App
-As mentioned, in order to verify that your changes work as expected, you will need to register your own GitHub App for testing purposes:
-
-##### Starting the Process
-- Click on your profile photo at the top right of any page within GitHub.
-- Navigate to "Settings" > "Developer Settings" > "GitHub Apps"
-- Click on the "New GitHub App" button or follow the "Register a new GitHub App" link in the page description. This will take you to the configuration page.
-
-##### Configuring the App
-
-**GitHub App name:** Enter a unique name for your GitHub App. We suggest something like "OpenSearch-bot-[unique-id]".
-
-**Homepage URL:** Enter the URL of your fork of the `OpenSearch-bot` repository.
-
-**Webhook URL:** Enter the `ngrok` base URL with the endpoint `/api/webhooks` appended on the end (e.g., `https://****-****.ngrok-free.app/api/webhooks`).
-
-**Webhook secret (optional):** Please provide a secure secret in this field. It can be any string of text. You will need to add this secret as an environment variable in your forked repository, as well (instructions below).
-
-**Permissions:** Click on the "Repository permissions" dropdown menu and set the following access permissions:
-- **Contents:** Read and write
-- **Metadata:** Read only
-- **Pull requests:** Read and write
-- **Secrets:** Read and write
-- **Webhooks:** Read and write
-
-**Subscribe to events:** Select the "Pull request" checkbox.
-
-**Where can this GitHub App be installed?** Select "Any account".
-
-##### Finalizing App Settings
-
-Once you have configured the app as outlined above, click the "Create GitHub App" button. You will be directed to a settings page for your newly-registered app.
-
-For the OAuth user authorization process, you will need to generate a **client secret:**
-- Under the "Client secrets" section, click the "Generate a new client secret" button.
-- Copy this secret and store it in a secure location.
-- Click the green "Save changes" button farther down the page.
-
-Additionally, your app requires a **private key** to authenticate itself with GitHub:
-- Scroll down to the "Private keys" section at the bottom of the settings page.
-- Click "Generate a private key" and download the `.pem` file to a secure location.
-
-#### Create a `.gitignore` File
-
-In your local repository, create a `.gitignore` file in your root directory containing the following:
-
-```
-*.pem
-
-coverage/
-
-node_modules/
-dist/
-.env
-```
-
-#### Create a `.env` File
-
-The Express server for this code base uses environment variables. In the root directory of your local repository, create a `.env` file with the following variables. (The values are for illustration purposes only.)
-
-```
-GITHUB_APP_IDENTIFIER="123456"
-PRIVATE_KEY_PATH="your-private-key-path.pem"
-GITHUB_WEBHOOK_SECRET="your-webhook-secret"
-PORT=3000
-```
-
-The `GITHUB_APP_IDENTIFIER` will be the six-digit "App ID" provided at the top of your GitHub App's settings page. This number 
-
-For the `PRIVATE_KEY_PATH` variable, enter the path to the `.pem` file you downloaded earlier. If you have added the file to the root directory of your local repository, you can simply include the file name here. 
-
-**IMPORTANT:** Make sure you have added `.pem` file types to your `.gitignore` file!
-
-Your `GITHUB_WEBHOOK_SECRET` will be the secret you provided when you first registered your app.
-
-Lastly, the `PORT` can be whatever port your local server is running on.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,141 @@
+<!-- omit in toc -->
+# OpenSearch-bot
+
+This project contains the source code for a GitHub App that automates the release process in OpenSearch repositories. The app works as follows:
+1. **PR Changelog Processing:** When a user opens a pull request (PR) from a forked repository against an OpenSearch repository, the app scans the PR description, looking for changelog entries listed in a "Changelog" section. It then generates a changeset file from these entries and commits this file to the open PR.
+2. **Automating Release Documentation:** When the PR is merged, the changeset file is stored in a designated directory in the base repository. At the time of a new release, the app scans this directory and uses the changeset files to generate comprehensive release notes and update the changelog with new entries.
+
+This process ensures a streamlined and automated approach to maintaining up-to-date release documentation in OpenSearch repositories.
+
+<!-- omit in toc -->
+## Table of Contents
+- [Installation](#installation)
+  - [Installation for Repository Usage](#installation-for-repository-usage)
+    - [Installing on an OpenSearch Repository](#installing-on-an-opensearch-repository)
+    - [Installing on Forked Repositories](#installing-on-forked-repositories)
+  - [Setting Up the Codebase for Development](#setting-up-the-codebase-for-development)
+    - [Fork the `OpenSearch-bot` Repository](#fork-the-opensearch-bot-repository)
+    - [Use `ngrok` to Create a Secure Tunnel to Localhost](#use-ngrok-to-create-a-secure-tunnel-to-localhost)
+    - [Register Your Own GitHub App](#register-your-own-github-app)
+      - [Starting the Process](#starting-the-process)
+      - [Configuring the App](#configuring-the-app)
+      - [Finalizing App Settings](#finalizing-app-settings)
+    - [Create a `.gitignore` File](#create-a-gitignore-file)
+    - [Create a `.env` File](#create-a-env-file)
+
+## Installation
+
+This section outlines the steps for installing and setting up the `OpenSearch-bot` GitHub App. It addresses:
+- Users who want to install the app on repositories they own or maintain. 
+- Developers interested in contributing to or customizing the source code for their own use cases.
+
+### Installation for Repository Usage
+
+In order for the app to work as intended, it must be installed both on an OpenSearch repository as well as on any forked repositories that PRs originate from.
+
+#### Installing on an OpenSearch Repository
+
+- Navigate to the [OpenSearch-bot](https://github.com/apps/opensearch-bot) installation page and click "Install". 
+- Select the OpenSearch repository where this app will manage PRs and process changeset files.
+- Follow the instructions to complete the installation.
+
+#### Installing on Forked Repositories
+
+- In the forked OpenSearch repository, navigate to the [OpenSearch-bot](https://github.com/apps/opensearch-bot) installation page and click "Install".
+- Follow the instructions to complete the installation on the forked repository.
+
+### Setting Up the Codebase for Development
+
+For developers who would like to contribute to the `OpenSearch-bot` source code or customize it for their own use cases, the following instructions lay out the process for setting up a local development environment.
+
+#### Fork the `OpenSearch-bot` Repository
+
+- Create your own fork of the `OpenSearch-bot` repository on GitHub.
+- Clone your forked repository onto your local machine.
+- From the root directory of your forked repository, run `npm i` to install all project dependencies.
+
+#### Use `ngrok` to Create a Secure Tunnel to Localhost
+
+This GitHub App relies on webhooks for its functionality. To test your changes, you will need to register your own GitHub App (instructions below) and configure it with a webhook URL. Use `ngrok` to set up a secure tunnel to your local server for webhook testing.
+
+- Download and install `ngrok` from [ngrok.com/download](https://ngrok.com/download).
+- Sign up for a free `ngrok` account to receive an authtoken for your configuration.
+- Start an `ngrok` tunnel with the command `ngrok http [port]` (e.g., `ngrok http 3000`).
+- The "Forwarding" URL displayed by `ngrok` (e.g., `https://****-****.ngrok-free.app`) will serve as the base of the webhook URL you will need below.
+
+#### Register Your Own GitHub App
+As mentioned, in order to verify that your changes work as expected, you will need to register your own GitHub App for testing purposes:
+
+##### Starting the Process
+- Click on your profile photo at the top right of any page within GitHub.
+- Navigate to "Settings" > "Developer Settings" > "GitHub Apps"
+- Click on the "New GitHub App" button or follow the "Register a new GitHub App" link in the page description. This will take you to the configuration page.
+
+##### Configuring the App
+
+**GitHub App name:** Enter a unique name for your GitHub App. We suggest something like "OpenSearch-bot-[unique-id]".
+
+**Homepage URL:** Enter the URL of your fork of the `OpenSearch-bot` repository.
+
+**Webhook URL:** Enter the `ngrok` base URL with the endpoint `/api/webhooks` appended on the end (e.g., `https://****-****.ngrok-free.app/api/webhooks`).
+
+**Webhook secret (optional):** Please provide a secure secret in this field. It can be any string of text. You will need to add this secret as an environment variable in your forked repository, as well (instructions below).
+
+**Permissions:** Click on the "Repository permissions" dropdown menu and set the following access permissions:
+- **Contents:** Read and write
+- **Metadata:** Read only
+- **Pull requests:** Read and write
+- **Secrets:** Read and write
+- **Webhooks:** Read and write
+
+**Subscribe to events:** Select the "Pull request" checkbox.
+
+**Where can this GitHub App be installed?** Select "Any account".
+
+##### Finalizing App Settings
+
+Once you have configured the app as outlined above, click the "Create GitHub App" button. You will be directed to a settings page for your newly-registered app.
+
+For the OAuth user authorization process, you will need to generate a **client secret:**
+- Under the "Client secrets" section, click the "Generate a new client secret" button.
+- Copy this secret and store it in a secure location.
+- Click the green "Save changes" button farther down the page.
+
+Additionally, your app requires a **private key** to authenticate itself with GitHub:
+- Scroll down to the "Private keys" section at the bottom of the settings page.
+- Click "Generate a private key" and download the `.pem` file to a secure location.
+
+#### Create a `.gitignore` File
+
+In your local repository, create a `.gitignore` file in your root directory containing the following:
+
+```
+*.pem
+
+coverage/
+
+node_modules/
+dist/
+.env
+```
+
+#### Create a `.env` File
+
+The Express server for this code base uses environment variables. In the root directory of your local repository, create a `.env` file with the following variables. (The values are for illustration purposes only.)
+
+```
+GITHUB_APP_IDENTIFIER="123456"
+PRIVATE_KEY_PATH="your-private-key-path.pem"
+GITHUB_WEBHOOK_SECRET="your-webhook-secret"
+PORT=3000
+```
+
+The `GITHUB_APP_IDENTIFIER` will be the six-digit "App ID" provided at the top of your GitHub App's settings page. This number 
+
+For the `PRIVATE_KEY_PATH` variable, enter the path to the `.pem` file you downloaded earlier. If you have added the file to the root directory of your local repository, you can simply include the file name here. 
+
+**IMPORTANT:** Make sure you have added `.pem` file types to your `.gitignore` file!
+
+Your `GITHUB_WEBHOOK_SECRET` will be the secret you provided when you first registered your app.
+
+Lastly, the `PORT` can be whatever port your local server is running on.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This project contains the source code for a GitHub App that automates the releas
   - [Installing on an OpenSearch Repository](#installing-on-an-opensearch-repository)
   - [Installing on Forked Repositories](#installing-on-forked-repositories)
 - [Features](#features)
+- [Contributing](#contributing)
 - [License](#license)
 
 ## Installation
@@ -40,6 +41,10 @@ The app works as follows:
 
 This process ensures a streamlined and automated approach to maintaining up-to-date release documentation in OpenSearch repositories.
 
+## Contributing
+
+Developers interested in contributing to this project can visit the [Developer Guide](docs/DEVELOPER_GUIDE.md) for instructions on how to set up the project in their local environment.
+
 ## License
 
-This app is licensed under the MIT License.
+This app is licensed under the [MIT License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ This project contains the source code for a GitHub App that automates the releas
 <!-- omit in toc -->
 ## Table of Contents
 - [Installation](#installation)
-  - [Installing on an OpenSearch Repository](#installing-on-an-opensearch-repository)
-  - [Installing on Forked Repositories](#installing-on-forked-repositories)
 - [Features](#features)
+- [Usage](#usage)
+- [Acknowledgements](#acknowledgements)
 - [Contributing](#contributing)
 - [License](#license)
 
@@ -20,12 +20,14 @@ This project contains the source code for a GitHub App that automates the releas
 
 In order for the app to work as intended, it must be installed both on an OpenSearch repository as well as on any forked repositories that PRs originate from.
 
+<!-- omit from toc -->
 ### Installing on an OpenSearch Repository
 
 - Navigate to the [OpenSearch-bot](https://github.com/apps/opensearch-bot) installation page and click "Install". 
 - Select the OpenSearch repository where this app will manage PRs and process changeset files.
 - Follow the instructions to complete the installation.
 
+<!-- omit from toc -->
 ### Installing on Forked Repositories
 
 - In the forked OpenSearch repository, navigate to the [OpenSearch-bot](https://github.com/apps/opensearch-bot) installation page and click "Install".
@@ -35,11 +37,52 @@ In order for the app to work as intended, it must be installed both on an OpenSe
 
 The app works as follows:
 
-1. **PR Changelog Processing:** When a user opens a pull request (PR) from a forked repository against an OpenSearch repository, the app scans the PR description, looking for changelog entries listed in a "Changelog" section. It then generates a changeset file from these entries and commits this file to the open PR.
+1. **PR Changelog Processing:** When a user opens or edits a pull request (PR) from a forked repository against an OpenSearch repository, the app scans the PR description, looking for changelog entries listed in a "Changelog" section. It then generates a changeset file from these entries and commits this file to the open PR.
    
 2. **Automating Release Documentation:** When the PR is merged, the changeset file is stored in a designated directory in the base repository. At the time of a new release, the app scans this directory and uses the changeset files to generate comprehensive release notes and update the changelog with new entries.
 
 This process ensures a streamlined and automated approach to maintaining up-to-date release documentation in OpenSearch repositories.
+
+For a more detailed walkthrough of the `OpenSearch-bot` app's features, see our [Feature Details](docs/FEATURE_DETAILS.md) document.
+
+## Usage
+
+In order for this app to work as intended, whenever a PR is opened from an OpenSearch fork against the base repository, the PR description must include a `## Changelog` heading.
+
+Beneath this heading is where you will add a changelog entry or entries summarizing your contribution.
+
+In order for the app to parse your entries and generate changeset files, each entry must:
+
+- begin with a hyphen followed by a space ("- ")
+- include one of the following category prefixes, followed by a colon:
+  - breaking
+  - chore
+  - deprecate
+  - doc
+  - feat
+  - fix
+  - infra
+  - refactor
+  - security
+  - skip
+  - test
+- conclude with a description of your contribution in the imperative mood using no more than 100 characters
+
+If the changes introduced in your PR are minor (e.g., fixing a typo), you can enter `- skip` in the "Changelog" section to instruct the app not to generate a changeset file. Please note that, if you enter `-skip` in the "Changelog" section, no other categories or descriptions can be present.
+
+Here is an example of a properly-formatted changelog entry in a PR description:
+
+```markdown
+## Changelog
+
+- feat: Add new feature
+```
+
+The app is equipped with robust error handling so that, if your PR description lacks the required information or needs reformatting in some way, the process will terminate and a comment will be added to your PR explaining what needs to be fixed.
+
+## Acknowledgements
+
+This app was developed by [Samuel Valdes Gutierrez](https://github.com/BigSamu), [Johnathon Bowers](https://github.com/JohnathonBowers), [Qiwen Li](https://github.com/MadaniKK), and [Will Yang](https://github.com/CMDWillYang), under the supervision of [Josh Romero](https://github.com/joshuarrrr), [Ashwin P. Chandran](https://github.com/ashwin-pc), [Matt Provost](https://github.com/BSFishy), and [Anan Zhuang](https://github.com/ananzh).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ This process ensures a streamlined and automated approach to maintaining up-to-d
 
 ## Contributing
 
-Developers interested in contributing to this project can visit the [Developer Guide](docs/DEVELOPER_GUIDE.md) for instructions on how to set up the project in their local environment.
+Contributions to the `OpenSearch-bot` are welcome! See our [Developer Guide](docs/DEVELOPER_GUIDE.md) for instructions on how to set up the project in your local environment. If you have any suggestions for how to improve the app, please feel free to open an issue or submit a pull request.
 
 ## License
 

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -110,9 +110,7 @@ Provide the URL of your fork of the `OpenSearch-bot` repository.
 To generate this URL, you will need to activate `ngrok`: 
 
 - Open your command line and start an `ngrok` tunnel with the command `ngrok http [port]`, replacing `[port]` with the port number your local server is running on (e.g., `ngrok http 3000`).
-  
 - Locate the "Forwarding" URL displayed by `ngrok` (e.g., `https://****-****.ngrok-free.app`).
-  
 - In the "Webhook URL" field on your GitHub App's configuration page, enter this `ngrok` forwarding URL followed by the API endpoint `/api/webhook`. This combination forms the complete webhook URL.
 
 Your Webhook URL should resemble the following format:
@@ -152,15 +150,12 @@ Once you have configured the app as outlined above, click the "Create GitHub App
 For the OAuth user authorization process, you will need to generate a **client secret:**
 
 - Under the "Client secrets" section, click the "Generate a new client secret" button.
-  
 - Copy this secret and store it in a secure location.
-  
 - Click the green "Save changes" button farther down the page.
 
 Additionally, your app requires a **private key** to authenticate itself with GitHub:
 
 - Scroll down to the "Private keys" section at the bottom of the settings page.
-  
 - Click "Generate a private key" and download the `.pem` file to a secure location.
 
 ## Complete Local Environment Setup
@@ -252,58 +247,45 @@ As mentioned above, in order to replicate the scenario the `OpenSearch-bot` is d
 
 ### Install the App on Your Base Repository
 
-Since you are already signed in to your main account, begin by installing your GitHub App on your base repository:
+Since you are already signed in to your main account, begin by installing your GitHub App on your base repository.
 
-- Navigate to the public page of your GitHub App:
-  
-  - Click on your profile photo at the top right of any GitHub page.
-  
-  - Select "Settings" from the dropdown menu.
-  
-  - On the next page, scroll down to the bottom of the menu on the left side of the page and click "Developer settings"
-  
-  - You should see your GitHub App listed under the "GitHub Apps" heading. Click on the "Edit" button beside your app.
-  
-  - At the bottom of the left menu on the edit page, you should see a menu option called "Public page". Click on this.
-  
-  - You will be taken to the public URL for your GitHub App. Be sure to record this URL, as you will need it to install your app on your second GitHub repository (see below).
+<!-- omit in toc -->
+#### Navigate to Your GitHub App's Public Page
 
-- Click on the green "Install" button.
+- Click on your profile photo at the top right of any GitHub page.
+- Select "Settings" from the dropdown menu.  
+- Scroll down to "Developer settings" at the bottom of the left side menu. 
+- Under the "GitHub Apps" heading, find your app and click "Edit".
+- In the edit page menu, select "Public page" to go to your GitHub App's public URL. Record this URL for future use.
 
+<!-- omit in toc -->
+#### Install the App
+
+- On the public page of your GitHub App, click the green "Install" button.
 - Select the account where you want to install the app.
-
-- Choose whether you want to install the app on all your repositories or only on select repositories.
-
+- Choose whether you want to install the app on all your repositories or only on select ones:
   - If you choose "Only select repositories", be sure that your base repository is included among your options.
-  
-- Click on the green "Install" button.
+- Confirm the installation by clicking on the green "Install" button.
 
 ### Sign In to a Second GitHub Account
 
 If you already own a second GitHub account, and you are also signed in to that second account:
 
 - Click on your profile photo at the top right of the screen.
-
 - Select the "Switch account" dropdown menu.
-
 - Find the account you want to switch to, and click on that account name.
 
 If you are not signed in to your second account:
 
 - Click on your profile photo.
-
 - Select "Add account".
-
 - Sign in to your second account.
 
 If you do not already own a second GitHub account, you will need to register one:
 
 - Click on your profile photo.
-  
 - Select "Sign out".
-  
 - On the "Select account to sign out" page, select "Sign out from all accounts".
-  
 - From GitHub's home page, follow the process to register a new account.
 
 ### Fork Your Base Repository and Install Your App
@@ -317,26 +299,20 @@ Once your fork has been created, navigate to the URL of your GitHub App and foll
 Now that your app is installed on your forked repository, return to your fork and commit a simple change. For example:
 
 - Select the "Add file" dropdown button from the main page of your fork.
-  
 - Select "Create new file".
-  
 - Name your file (e.g., "test.txt") and enter some text in the text area that says, "Enter file contents here".
-  
 - Click the green "Commit changes..." button.
-  
 - In the modal window that opens, click on the green "Commit changes" button.
 
 Next, open a pull request against your base repository:
 
 - Click on the "Contribute" dropdown menu button.
-  
 - You should see a message like "This branch is 1 commit ahead of" followed by the name of your base repository.
-  
 - Click on the green "Open pull request" button.
-  
 - On the next screen click on the green "Create pull request" button.
 
-**IMPORTANT:** For the GitHub App to work as intended, you will need to add a "## Changelog" heading in the "Add a description" text area. Below that heading, enter a hyphen followed by a space and one of the following prefixes: 
+**IMPORTANT:** For the GitHub App to work as intended, you will need to add a "## Changelog" heading in the "Add a description" text area. Below that heading, enter a hyphen followed by a space and one of the following prefixes:
+
  - breaking
  - chore
  - deprecate
@@ -351,7 +327,7 @@ Next, open a pull request against your base repository:
 
 After the prefix, add a colon and then a brief description of your changes. Your description should look something like this:
 
-```
+```markdown
 ## Changelog
 
 - doc: Add test.txt

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -1,0 +1,220 @@
+<!-- omit in toc -->
+# Developer Guide
+
+If you are interested in contributing to the `OpenSearch-bot` GitHub App or customizing the app to fit your particular use case, the following instructions will guide you through the process of setting up your developer environment.
+
+<!-- omit in toc -->
+## Table of Contents
+- [Introduction](#introduction)
+- [Initialize Local Environment Setup](#initialize-local-environment-setup)
+- [Register Your Own GitHub App](#register-your-own-github-app)
+  - [Initiate the Process](#initiate-the-process)
+  - [Configure the App](#configure-the-app)
+  - [Finalize App Settings](#finalize-app-settings)
+- [Complete Local Environment Setup](#complete-local-environment-setup)
+  - [Start Your Local Server](#start-your-local-server)
+- [Fork Your Base Repo](#fork-your-base-repo)
+  - [Sign In to a Second GitHub Account](#sign-in-to-a-second-github-account)
+  - [Install Your App](#install-your-app)
+
+## Introduction
+
+The `OpenSearch-bot` GitHub App is designed for scenarios in which a contributor to an OpenSearch repository opens a pull request from a branch in their forked OpenSearch repository. Therefore, in order to ensure your changes work as expected, you will need to replicate this scenario by performing the following actions:
+
+- Initialize the setup of your local environment. This will be your base repository.
+- Create your own GitHub App from your base repository.
+- Complete the setup of your local environment.
+- Use a second GitHub account to create a fork of your base repository.
+- Install your GitHub App on both your base and your forked repository.
+- Open a pull request from your forked repository to your base repository.
+
+The following sections detail how to perform each of these actions.
+
+## Initialize Local Environment Setup
+
+The first step toward replicating the scenario the `OpenSearch-bot` GitHub App is designed for is to set up secure remote access to your own version of the source code.  
+
+<!-- omit in toc -->
+### Fork the `OpenSearch-bot` Repository
+
+- Create your own fork of the `OpenSearch-bot` repository on GitHub.
+- Clone your forked repository onto your local machine.
+- From the root directory of your forked repository, run `npm i` to install all project dependencies.
+
+<!-- omit in toc -->
+### Install `ngrok` on Your Local Machine
+
+This GitHub App relies on webhooks for its functionality. To test your changes, you will need to register your own GitHub App (instructions below) and configure it with a webhook URL. `ngrok` is a useful tool for establishing a secure tunnel to your local server, which will generate the necessary webhook URL.
+
+At this point in the process, you only need to install `ngrok`. You won't need to start an `ngrok` tunnel until you are registering your GitHub App.
+
+- Download and install `ngrok` from [ngrok.com/download](https://ngrok.com/download).
+- Sign up for a free `ngrok` account to receive an authtoken.
+- Follow the instructions to add your authtoken to your `ngrok` configuration.
+
+<!-- omit in toc -->
+### Verify the Contents of Your `.gitignore` File
+
+Before moving forward, it's crucial to ensure that sensitive information does not get accidentally pushed to your remote repository on GitHub. Please ensure that the `.gitignore` file in your forked repository includes the following entries:
+
+```
+*.pem
+
+coverage/
+
+node_modules/
+dist/
+.env
+```
+
+These entries prevent Git from tracking certain files and directories:
+
+`*.pem`: Excludes private key files, which are sensitive and should remain confidential.
+
+`coverage/`, `node_modules/`, and `dist/`: While these directories do not necessarily contain sensitive information, excluding them avoids unnecessary clutter in your repository. They typically contain generated reports, installed dependencies, and built files, respectively.
+
+`.env`: Critical for omitting environment variables that contain sensitive configuration settings and secrets.
+
+You will add the `.pem` file and `.env` file to your local repository in a later step.
+
+## Register Your Own GitHub App
+
+As mentioned above, in order to verify that your changes work as expected, you will need to register your own GitHub App for testing purposes:
+
+### Initiate the Process
+
+- Click on your profile photo at the top right of any page within GitHub.
+- Navigate to "Settings" > "Developer Settings" > "GitHub Apps"
+- Click on the "New GitHub App" button or follow the "Register a new GitHub App" link in the page description. This will take you to the configuration page.
+
+### Configure the App
+
+The configuration page provides a number of options for customizing a GitHub App for specific use cases. Below is the information you will need to set up an `OpenSearch-bot` clone. The subheadings in this section represent the field labels where you will provide this information.
+
+<!-- omit in toc -->
+#### GitHub App name
+
+Enter a unique name for your GitHub App. We suggest something like "OpenSearch-bot-[unique-id]".
+
+<!-- omit in toc -->
+#### Homepage URL
+
+Provide the URL of your fork of the `OpenSearch-bot` repository.
+
+<!-- omit in toc -->
+#### Webhook URL
+
+To generate this URL, you will need to activate `ngrok`: 
+
+- Open your command line and start an `ngrok` tunnel with the command `ngrok http [port]`, replacing `[port]` with the port number your local server is running on (e.g., `ngrok http 3000`).
+  
+- Locate the "Forwarding" URL displayed by `ngrok` (e.g., `https://****-****.ngrok-free.app`).
+  
+- In the "Webhook URL" field on your GitHub App's configuration page, enter this `ngrok` forwarding URL followed by the API endpoint `/api/webhooks`. This combination forms the complete webhook URL.
+
+Your Webhook URL should resemble the following format:
+```
+https://****-****.ngrok-free.app/api/webhooks
+```
+
+<!-- omit in toc -->
+#### Webhook secret (optional)
+
+Enter a secure secret in this field. It can be any string of text. You will need to add this secret as an environment variable in your forked repository, as well (instructions below).
+
+<!-- omit in toc -->
+#### Permissions
+
+Click on the "Repository permissions" dropdown menu and set the following access permissions:
+- **Contents:** Read and write
+- **Metadata:** Read only
+- **Pull requests:** Read and write
+- **Secrets:** Read and write
+- **Webhooks:** Read and write
+
+<!-- omit in toc -->
+#### Subscribe to events
+
+Select the "Pull request" checkbox.
+
+<!-- omit in toc -->
+#### Where can this GitHub App be installed?
+
+Select "Any account".
+
+### Finalize App Settings
+
+Once you have configured the app as outlined above, click the "Create GitHub App" button. You will be directed to a settings page for your newly-registered app.
+
+For the OAuth user authorization process, you will need to generate a **client secret:**
+
+- Under the "Client secrets" section, click the "Generate a new client secret" button.
+  
+- Copy this secret and store it in a secure location.
+  
+- Click the green "Save changes" button farther down the page.
+
+Additionally, your app requires a **private key** to authenticate itself with GitHub:
+
+- Scroll down to the "Private keys" section at the bottom of the settings page.
+  
+- Click "Generate a private key" and download the `.pem` file to a secure location.
+
+## Complete Local Environment Setup
+
+With the information obtained from registering your GitHub App, you may now complete the setup of your local environment.
+
+<!-- omit from toc -->
+### Create a `.env` File
+
+The Express server for this code base relies on environment variables for its configuration. In the root directory of your local repository, create a `.env` file with the following variables. (Note that the values provided here are examples.)
+
+```
+GITHUB_APP_IDENTIFIER="123456"
+PRIVATE_KEY_PATH="your-private-key-path.pem"
+GITHUB_WEBHOOK_SECRET="your-webhook-secret"
+PORT=3000
+```
+
+`GITHUB_APP_IDENTIFIER`: This is the six-digit "App ID" provided at the top of your GitHub App's settings page.
+
+`PRIVATE_KEY_PATH`: Enter the absolute or relative path to the `.pem` file you downloaded earlier. If the file is in your projects root directory, simply enter the file name. 
+
+`GITHUB_WEBHOOK_SECRET`: Use the secret you provided when you first registered your app.
+
+`PORT`: This can be any available port number on which your local server will run. The example here uses `3000`.
+
+**IMPORTANT:** Double-check that you have `*.pem` and `.env` listed in your `.gitignore` file.
+
+### Start Your Local Server
+
+Once your `.env` file is properly configured, you are ready to start your local server.
+
+This project uses Express for its server framework, and the server's entry point is the `main.js` file located in the root directory. 
+
+## Fork Your Base Repo
+
+As mentioned above, in order to replicate the scenario the `OpenSearch-bot` is designed to address, you will need to install your own GitHub App on your base repo as well as on a fork of this repo belonging to a different owner. To create this forked repo, you will need to use a second GitHub account.
+
+### Sign In to a Second GitHub Account
+
+If you already own a second GitHub account, and you are also signed in to that second account:
+- Click on your profile photo at the top right of the screen.
+- Select the "Switch account" dropdown menu.
+- Find the account you want to switch to, and click on that account name.
+
+If you are not signed in to your second account:
+- Click on your profile photo.
+- Select "Add account".
+- Sign in to your second account.
+
+If you do not already own a second GitHub account, you will need to register one:
+- Click on your profile photo.
+- Select "Sign out".
+- On the "Select account to sign out" page, select "Sign out from all accounts".
+- From GitHub's home page, follow the process to register a new account.
+
+### Install Your App
+
+As mentioned 
+

--- a/docs/FEATURE_DETAILS.md
+++ b/docs/FEATURE_DETAILS.md
@@ -1,0 +1,93 @@
+<!-- omit in toc -->
+# Feature Details
+
+This document describes the key features of the `OpenSearch-bot` GitHub App. It addresses both the changeset generation process as well as the release documentation process.
+
+<!-- omit in toc -->
+## Table of Contents
+- [Changeset Generation Process](#changeset-generation-process)
+  - [Overview](#overview)
+  - [Process Flowchart](#process-flowchart)
+- [Release Documentation Process](#release-documentation-process)
+
+## Changeset Generation Process
+
+### Overview
+
+The `OpenSearch-bot` GitHub App subscribes to webhooks that listen for the creation or editing of a pull request (PR). When a PR from a forked repository is opened against an OpenSearch repository, or when that PR is edited, the app extracts the metadata from the PR and checks what a contributor has entered in the "Changelog" section of the PR description.
+
+If a contributor has entered valid changelog entries (see the "Usage" section in the project's [README](../README.md) for details), the workflow will categorize these entries and either create or update a `.yml` changeset file in the `changelogs/fragments` directory of the repository. If this directory does not exist, the app will create one.
+
+The changeset file will include changelog descriptions under their proper category and also add a link to the PR that generated these changes. Below is an example of what the contents of a changeset file will look like:
+
+```yaml
+feat:
+  - Add a new feature ([#532](https://github.com/.../pull/532))
+```
+
+In this example, the path to this file would be `changelogs/fragments/532.yml`.
+
+This changeset file will become part of the code that is merged into the base repository when the PR is approved.
+
+If the app encounters a `- skip` line in the PR description, and there are no other changelog entries present, it will skip the creation of a changeset file, and the process will terminate successfully.
+
+If the app encounters a formatting error in the PR description (e.g., an empty "Changelog" section or an invalid changelog entry), the process will fail, and a custom error message will be added as a comment to the open PR explaining the reason for the failure.
+
+Contributors can then address the error and update their PR description, which will trigger the process to run again.
+
+### Process Flowchart
+
+The following flow chart, built using [Mermaid](https://mermaid.js.org/) syntax, illustrates the logic the changeset generation process follows.
+
+(NOTE: If you are viewing this README in an IDE or code editor, the flow chart will not render. To view the chart, please visit this README file on GitHub's website, which includes built-in support for Mermaid syntax.)
+
+```mermaid
+%%{init: {'themeVariables': { 'fontSize': '24px' }}}%%
+  flowchart TD;
+    A(Changelog \Process Starts) --> B{Changelog section\n present in PR?}
+    B --> |Yes| C[Extract changelog entries from\n'Changelog' section of PR]
+    B --> |No| D[InvalidChangelogHeadingError \nEmptyChangelogSectionError]
+    D --> E[Error messsage added as comment to PR]
+    E --> F(Workflow fails)
+    F --> G[Contributor edits PR]
+    G --> A
+    C --> H[Prepare changeset entry map]
+    H --> I{Entries in PR \nformatted correctly?}
+    I --> |Yes| J{'skip' in changeset \n entry map?}
+    I --> |No| K[ChangelogEntryMissingHyphenError\nInvalidPrefixError\nEmptyEntryDescriptionError\nEntryTooLongError]
+    K --> E
+    J --> |Yes| L{Is 'skip' the \nonly entry?}
+    J --> |No| M[Changset file created / updated]
+    M --> N(Workflow ends successfully)
+    L --> |Yes| O['skip-changelog' label added to PR]
+    O --> P[No changeset file created / updated]
+    P --> N
+    L --> |No| Q[CategoryWithSkipOptionError]
+    Q --> E
+
+    style A fill:#38bdf8,color:#0f172a
+    style B fill:#fbbf24,color:#0f172a
+    style D fill:#fb923c,color:#0f172a
+    style F fill:#ef4444,color:#f8fafc
+    style G fill:#c084fc,color:#0f172a
+    style I fill:#fbbf24,color:#0f172a
+    style J fill:#fbbf24,color:#0f172a
+    style K fill:#fb923c,color:#0f172a
+    style L fill:#fbbf24,color:#0f172a
+    style Q fill:#fb923c,color:#0f172a
+    style N fill:#4ade80,color:#0f172a
+```
+
+## Release Documentation Process
+
+When a new product release is ready for general availability, OpenSearch maintainers can run the following command from the command line:
+
+```bash
+yarn release_note:generate
+```
+This command executes a script that performs the following actions:
+- Extract information from the changeset files in the `changelogs/fragments` directory
+- Map the changelog entries in these files to their appropriate changelog section headings
+- Generate the changelog section for the new release and add it to the top of the changelog document
+- Create a release notes document to accompany the new release
+- Delete the changeset files from the `changelogs/fragments` directory


### PR DESCRIPTION
## Description

This PR introduces the following changes:
- Create a `docs` directory to house project documentation aside from the main `README.md` file.
- Create a project `README` which includes badges as well as links to the Developer Guide and Feature Details documents.
- Add an MIT license
- Create a `DEVELOPER_GUIDE.md` and `FEATURE_DETAILS.md` document

## Issues

This PR resolves Issue #24 and Issue #7.